### PR TITLE
add use jquery

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,7 +3,7 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
+  api.use('jquery', 'client');
   api.add_files('parsley.min.js', 'client');
   api.add_files('parsley.remote.min.js', 'client');
 });
-


### PR DESCRIPTION
Without this addition, we are getting 
Uncaught TypeError: Cannot read property 'extend' of undefined in 'parsley.remote.min.js'

It's saying jquery is undefined.  Adding this fixes the issue.
